### PR TITLE
(doc) improve clarity on why an IDE/Editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 #### software
    - [etcher](https://www.balena.io/etcher/) or dd
    - latest copy of [Hypriot](https://github.com/hypriot/image-builder-rpi/releases)
-   - IDE
+   - IDE or $EDITOR of choice for changing passwords in files located in src/*
    
 #### hardware
    - [64Gb+ sdcard](https://www.amazon.com/dp/B073JYVKNX/)


### PR DESCRIPTION
Changes:
   - Added details on why an editor is needed
   - included usual unix $EDITOR of choice (means *ANY* text editor) to eliminate the scare of "IDE needed -> programming skills needed"